### PR TITLE
Add an executable file command for Mac OS users

### DIFF
--- a/BetterDiscordPanel.command
+++ b/BetterDiscordPanel.command
@@ -1,0 +1,7 @@
+cd "$(dirname "$0")"
+
+TITLE BetterDiscordPanel
+clear
+echo .
+cd scripts
+pwsh -ExecutionPolicy Bypass ./Selection.ps1


### PR DESCRIPTION
This works just note you need to install PowerShell for mac

[docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2)